### PR TITLE
chore: generate sudokus using seed, added generation test

### DIFF
--- a/scripts/generate_sudokus.ts
+++ b/scripts/generate_sudokus.ts
@@ -4,6 +4,7 @@ import * as generate from "../src/engine/generate";
 import * as solverAC3 from "../src/engine/solverAC3";
 import {printSimpleSudoku} from "../src/engine/utility";
 import {DIFFICULTY} from "../src/engine/types";
+import {createSeededRandom} from "../src/engine/seededRandom";
 
 program
   .version("0.0.1")
@@ -42,7 +43,9 @@ ${printedSudoku}
 
 const number = options.number;
 console.log(`Generate ${number} sudokus with difficulty ` + difficulty);
+
+const randomFn = createSeededRandom(Math.random() * +new Date());
 new Array(number).fill(0).forEach((_, i) => {
   console.log("Generate sudoku " + (i + 1));
-  writeSudoku(generate.generateSudoku(sudokuDifficulty));
+  writeSudoku(generate.generateSudoku(sudokuDifficulty, randomFn));
 });

--- a/src/engine/__tests__/generate.ts
+++ b/src/engine/__tests__/generate.ts
@@ -1,0 +1,28 @@
+import generateSudoku, {checkForUniqueness} from "../generate";
+import {createSeededRandom} from "../seededRandom";
+import {solve} from "../solverAC3";
+import {DIFFICULTY} from "../types";
+import {printSimpleSudoku} from "../utility";
+
+describe("generate", () => {
+  it("generates the same sudoku using a seed", () => {
+    const randomFn = createSeededRandom(10);
+    const sudoku = generateSudoku(DIFFICULTY.EASY, randomFn);
+    const stringified = printSimpleSudoku(sudoku);
+    expect(stringified).toBe(
+      `_8_9_25_6
+_61_78_4_
+_4__5___3
+_5_1_4_2_
+4_____9__
+_13_9__85
+____2____
+7258_____
+8__7_5_3_`,
+    );
+    // Check if it is unique.
+    expect(checkForUniqueness(sudoku)).toBe(true);
+    // Check if it can be solved.
+    expect(solve(sudoku).iterations).toBe(4);
+  });
+});

--- a/src/engine/seededRandom.ts
+++ b/src/engine/seededRandom.ts
@@ -1,0 +1,53 @@
+// Adding our own implementation of some random functions, but they take the random function.
+
+function cloneArray<T>(source: T[]): T[] {
+  let index = -1;
+  const length = source.length;
+
+  const array = new Array(length);
+  while (++index < length) {
+    array[index] = source[index];
+  }
+  return array;
+}
+
+// Taken from https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript/47593316#47593316
+function splitMix32(a: number) {
+  return function (): number {
+    a |= 0;
+    a = (a + 0x9e3779b9) | 0;
+    let t = a ^ (a >>> 16);
+    t = Math.imul(t, 0x21f0aaad);
+    t = t ^ (t >>> 15);
+    t = Math.imul(t, 0x735a2d97);
+    return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
+  };
+}
+
+export function createSeededRandom(seed: number) {
+  return splitMix32(seed);
+}
+
+// Copied from lodash, but added TypeScript typings.
+// https://github.com/lodash/lodash/blob/main/src/shuffle.ts
+export function shuffle<T>(array: T[], randomFn: () => number): T[] {
+  const length = array == null ? 0 : array.length;
+  if (!length) {
+    return [];
+  }
+  let index = -1;
+  const lastIndex = length - 1;
+  const result = cloneArray(array);
+  while (++index < length) {
+    const rand = index + Math.floor(randomFn() * (lastIndex - index + 1));
+    const value = result[rand];
+    result[rand] = result[index];
+    result[index] = value;
+  }
+  return result;
+}
+
+export function sample<T>(array: T[], randomFn: () => number): T {
+  const length = array == null ? 0 : array.length;
+  return length ? array[Math.floor(randomFn() * length)] : undefined;
+}


### PR DESCRIPTION
The generation is now seeded, so one can properly test the code without relying on some global state shenaningans. passing the `randomFn` to everything is arguably a bit ugly, but it does the job and make sit very explicit.