### PR TITLE
chore: move the undo button to where the other input actions are

### DIFF
--- a/src/components/pages/Game/GameControls/GameControlActions.tsx
+++ b/src/components/pages/Game/GameControls/GameControlActions.tsx
@@ -1,13 +1,42 @@
 import * as React from "react";
-import {clearCell, getHint} from "src/state/sudoku";
+import {clearCell, getHint, undo} from "src/state/sudoku";
 import styled from "styled-components";
-import {activateNotesMode, deactivateNotesMode} from "src/state/game";
+import {activateNotesMode, deactivateNotesMode, GameStateMachine} from "src/state/game";
 import Button from "../../../modules/Button";
 import {connect, ConnectedProps} from "react-redux";
 import {RootState} from "src/state/rootReducer";
 import clsx from "clsx";
 
 const ControlContainer = styled.div.attrs({className: "relative justify-center flex"})``;
+
+const undoButtonConnector = connect(
+  (state: RootState) => {
+    return {
+      state: state.game.state,
+      sudoku: state.sudoku,
+    };
+  },
+  {
+    undo,
+  },
+);
+
+type UndoButtonProps = ConnectedProps<typeof undoButtonConnector>;
+
+const UndoButton: React.FC<UndoButtonProps> = ({state, undo, sudoku}) => {
+  const canUndo = sudoku.historyIndex < sudoku.history.length - 1;
+  return (
+    <Button
+      className="w-full"
+      disabled={state === GameStateMachine.wonGame || state === GameStateMachine.paused || !canUndo}
+      onClick={undo}
+    >
+      {"Undo"}
+    </Button>
+  );
+};
+
+const ConnectedUndoButton = undoButtonConnector(UndoButton);
 
 const connector = connect(
   (state: RootState) => ({
@@ -26,7 +55,7 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 class SudokuMenuControls extends React.Component<PropsFromRedux> {
   render() {
     return (
-      <div className="mt-4 grid w-full grid-cols-3 gap-2">
+      <div className="mt-4 grid w-full grid-cols-4 gap-2">
         <ControlContainer>
           <Button
             onClick={() => (this.props.notesMode ? this.props.deactivateNotesMode() : this.props.activateNotesMode())}
@@ -45,6 +74,9 @@ class SudokuMenuControls extends React.Component<PropsFromRedux> {
           <Button className="w-full" onClick={() => this.props.getHint(this.props.activeCell!)}>
             {"Hint"}
           </Button>
+        </ControlContainer>
+        <ControlContainer>
+          <ConnectedUndoButton />
         </ControlContainer>
       </div>
     );

--- a/src/components/pages/Game/index.tsx
+++ b/src/components/pages/Game/index.tsx
@@ -50,34 +50,6 @@ const sudokuMenuNumbersConnector = connect(
 );
 const SudokuMenuNumbersConnected = sudokuMenuNumbersConnector(SudokuMenuNumbers);
 
-const undoButtonConnector = connect(
-  (state: RootState) => {
-    return {
-      state: state.game.state,
-      sudoku: state.sudoku,
-    };
-  },
-  {
-    undo,
-  },
-);
-
-type UndoButtonProps = ConnectedProps<typeof undoButtonConnector>;
-
-const UndoButton: React.FC<UndoButtonProps> = ({state, undo, sudoku}) => {
-  const canUndo = sudoku.historyIndex < sudoku.history.length - 1;
-  return (
-    <Button
-      disabled={state === GameStateMachine.wonGame || state === GameStateMachine.paused || !canUndo}
-      onClick={undo}
-    >
-      {"Undo"}
-    </Button>
-  );
-};
-
-const ConnectedUndoButton = undoButtonConnector(UndoButton);
-
 function PauseButton({
   state,
   pauseGame,
@@ -279,11 +251,8 @@ class Game extends React.Component<PropsFromRedux> {
                 <GameTimer />
               </div>
               <div className="flex">
-                <div className="mr-2">
-                  <PauseButton state={game.state} continueGame={continueGame} pauseGame={pauseGame} />
-                </div>
                 <div>
-                  <ConnectedUndoButton />
+                  <PauseButton state={game.state} continueGame={continueGame} pauseGame={pauseGame} />
                 </div>
               </div>
             </GameHeaderArea>


### PR DESCRIPTION
Moved the undo button as after seeing someone play, it became obvious that this is the better position.

![CleanShot 2024-08-25 at 20 25 27](https://github.com/user-attachments/assets/c87f7ce0-bc90-4bc2-8485-72d2cc949047)
