### PR TITLE
feat: preserve user preferences in localstorage

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -1,6 +1,7 @@
 import React, {createContext, useContext, useReducer, useCallback, ReactNode} from "react";
 import {CellCoordinates} from "src/lib/engine/types";
 import {START_SUDOKU_COLLECTION, START_SUDOKU_INDEX} from "src/lib/game/sudokus";
+import {localStorageUserPreferencesRepository} from "src/lib/database/userPreferences";
 
 export enum GameStateMachine {
   running = "RUNNING",
@@ -26,24 +27,41 @@ export interface GameState {
   secondsPlayed: number;
 }
 
-export const INITIAL_GAME_STATE: GameState = {
-  activeCellCoordinates: undefined,
-  sudokuCollectionName: START_SUDOKU_COLLECTION.name,
-  notesMode: false,
-  showCircleMenu: true,
-  showHints: false,
-  showConflicts: true,
-  showOccurrences: false,
-  showWrongEntries: false,
-  showMenu: false,
-  showNotes: false,
-  state: GameStateMachine.paused,
-  sudokuIndex: START_SUDOKU_INDEX,
-  secondsPlayed: 0,
-  timesSolved: 0,
-  previousTimes: [],
-  won: false,
-};
+function getInitialGameState(): GameState {
+  const savedPreferences = localStorageUserPreferencesRepository.getPreferences();
+
+  return {
+    activeCellCoordinates: undefined,
+    sudokuCollectionName: START_SUDOKU_COLLECTION.name,
+    notesMode: false,
+    showCircleMenu: savedPreferences.showCircleMenu,
+    showHints: savedPreferences.showHints,
+    showConflicts: savedPreferences.showConflicts,
+    showOccurrences: savedPreferences.showOccurrences,
+    showWrongEntries: savedPreferences.showWrongEntries,
+    showMenu: false,
+    showNotes: false,
+    state: GameStateMachine.paused,
+    sudokuIndex: START_SUDOKU_INDEX,
+    secondsPlayed: 0,
+    timesSolved: 0,
+    previousTimes: [],
+    won: false,
+  };
+}
+
+export const INITIAL_GAME_STATE: GameState = getInitialGameState();
+
+function saveUserPreferences(state: GameState): void {
+  const preferences = {
+    showHints: state.showHints,
+    showWrongEntries: state.showWrongEntries,
+    showConflicts: state.showConflicts,
+    showCircleMenu: state.showCircleMenu,
+    showOccurrences: state.showOccurrences,
+  };
+  localStorageUserPreferencesRepository.savePreferences(preferences);
+}
 
 // Action types
 const NEW_GAME = "game/NEW_GAME";
@@ -102,6 +120,7 @@ function gameReducer(state: GameState, action: GameAction): GameState {
     case SET_GAME_STATE:
       return action.state;
     case NEW_GAME:
+      const currentPreferences = localStorageUserPreferencesRepository.getPreferences();
       return {
         ...INITIAL_GAME_STATE,
         sudokuIndex: action.sudokuIndex,
@@ -109,6 +128,7 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         timesSolved: action.timesSolved,
         previousTimes: action.previousTimes,
         state: GameStateMachine.running,
+        ...currentPreferences,
       };
     case WON_GAME:
       const justWon = state.won === false;
@@ -134,6 +154,7 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         state: GameStateMachine.running,
       };
     case RESTART_GAME:
+      const restartPreferences = localStorageUserPreferencesRepository.getPreferences();
       return {
         ...state,
         sudokuIndex: action.sudokuIndex,
@@ -143,6 +164,11 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         previousTimes: action.previousTimes,
         state: GameStateMachine.running,
         won: false,
+        showHints: restartPreferences.showHints,
+        showWrongEntries: restartPreferences.showWrongEntries,
+        showConflicts: restartPreferences.showConflicts,
+        showCircleMenu: restartPreferences.showCircleMenu,
+        showOccurrences: restartPreferences.showOccurrences,
       };
     case SHOW_MENU:
       return {
@@ -162,30 +188,40 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         activeCellCoordinates: action.cellCoordinates,
       };
     case TOGGLE_SHOW_HINTS:
-      return {
+      const newStateHints = {
         ...state,
         showHints: !state.showHints,
       };
+      saveUserPreferences(newStateHints);
+      return newStateHints;
     case TOGGLE_SHOW_OCCURRENCES:
-      return {
+      const newStateOccurrences = {
         ...state,
         showOccurrences: !state.showOccurrences,
       };
+      saveUserPreferences(newStateOccurrences);
+      return newStateOccurrences;
     case TOGGLE_SHOW_CONFLICTS:
-      return {
+      const newStateConflicts = {
         ...state,
         showConflicts: !state.showConflicts,
       };
+      saveUserPreferences(newStateConflicts);
+      return newStateConflicts;
     case TOGGLE_SHOW_CIRCLE_MENU:
-      return {
+      const newStateCircleMenu = {
         ...state,
         showCircleMenu: !state.showCircleMenu,
       };
+      saveUserPreferences(newStateCircleMenu);
+      return newStateCircleMenu;
     case TOGGLE_SHOW_WRONG_ENTRIES:
-      return {
+      const newStateWrongEntries = {
         ...state,
         showWrongEntries: !state.showWrongEntries,
       };
+      saveUserPreferences(newStateWrongEntries);
+      return newStateWrongEntries;
     case ACTIVATE_NOTES_MODE:
       return {
         ...state,

--- a/src/lib/database/userPreferences.ts
+++ b/src/lib/database/userPreferences.ts
@@ -1,0 +1,61 @@
+const STORAGE_KEY_USER_PREFERENCES = "super-sudoku-user-preferences";
+
+export interface UserPreferences {
+  showHints: boolean;
+  showWrongEntries: boolean;
+  showConflicts: boolean;
+  showCircleMenu: boolean;
+  showOccurrences: boolean;
+}
+
+export const DEFAULT_USER_PREFERENCES: UserPreferences = {
+  showHints: false,
+  showWrongEntries: false,
+  showConflicts: true,
+  showCircleMenu: true,
+  showOccurrences: false,
+};
+
+interface UserPreferencesRepository {
+  getPreferences(): UserPreferences;
+  savePreferences(preferences: UserPreferences): void;
+}
+
+export const localStorageUserPreferencesRepository: UserPreferencesRepository = {
+  getPreferences(): UserPreferences {
+    if (typeof localStorage === "undefined") {
+      return DEFAULT_USER_PREFERENCES;
+    }
+
+    const storedPreferences = localStorage.getItem(STORAGE_KEY_USER_PREFERENCES);
+
+    if (!storedPreferences) {
+      return DEFAULT_USER_PREFERENCES;
+    }
+
+    try {
+      const parsed = JSON.parse(storedPreferences);
+
+      // Merge with defaults to handle cases where new preferences are added
+      return {
+        ...DEFAULT_USER_PREFERENCES,
+        ...parsed,
+      };
+    } catch (error) {
+      console.warn("Failed to parse user preferences from localStorage:", error);
+      return DEFAULT_USER_PREFERENCES;
+    }
+  },
+
+  savePreferences(preferences: UserPreferences): void {
+    if (typeof localStorage === "undefined") {
+      return;
+    }
+
+    try {
+      localStorage.setItem(STORAGE_KEY_USER_PREFERENCES, JSON.stringify(preferences));
+    } catch (error) {
+      console.warn("Failed to save user preferences to localStorage:", error);
+    }
+  },
+};

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -18,6 +18,7 @@ import {cellsToSimpleSudoku, stringifySudoku, parseSudoku} from "src/lib/engine/
 import {solve} from "src/lib/engine/solverAC3";
 import {Link, useLocation, useNavigate} from "@tanstack/react-router";
 import {localStoragePlayedSudokuRepository} from "src/lib/database/playedSudokus";
+import {localStorageUserPreferencesRepository} from "src/lib/database/userPreferences";
 import {formatDuration} from "src/utils/format";
 import {throttle} from "lodash";
 import {TimerProvider} from "src/context/TimerContext";
@@ -444,7 +445,19 @@ export function AppProvider({children}: {children: React.ReactNode}) {
     ? localStoragePlayedSudokuRepository.getSudokuState(currentSudokuKey)
     : undefined;
 
-  const initialGameState: GameState = currentSudoku ? currentSudoku.game : INITIAL_GAME_STATE;
+  // Load user preferences and merge with saved game state
+  const userPreferences = localStorageUserPreferencesRepository.getPreferences();
+  const initialGameState: GameState = currentSudoku
+    ? {
+        ...currentSudoku.game,
+        // Always use current user preferences, not saved game preferences
+        showHints: userPreferences.showHints,
+        showWrongEntries: userPreferences.showWrongEntries,
+        showConflicts: userPreferences.showConflicts,
+        showCircleMenu: userPreferences.showCircleMenu,
+        showOccurrences: userPreferences.showOccurrences,
+      }
+    : INITIAL_GAME_STATE;
 
   const initialSudokuState: SudokuState = currentSudoku
     ? {


### PR DESCRIPTION
Thank you for the app, I'm using it often and I'd like to contribute on something I found annoying.
Every time I start a new game I set different settings, so I think preserve the preferences in local storage might be a good UX.
