### PR TITLE
Add copy/paste shortcuts for cell notes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -39,6 +39,7 @@ Born from a simple request - my Grandma wanted to play Sudoku, but I wasn't sati
 | **Get Hint** | H |
 | **Toggle Notes** | N |
 | **Undo/Redo** | CMD/CTRL + Z/Y |
+| **Copy/Paste Notes** | CMD/CTRL + C/V |
 
 ### 🎯 **Smart Features**
 - **Auto-save**: Your progress is automatically saved

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -20,6 +20,7 @@ export interface GameState {
   timesSolved: number;
   previousTimes: number[];
   secondsPlayed: number;
+  clipboardNotes: number[] | null;
 }
 
 export const INITIAL_GAME_STATE: GameState = {
@@ -34,6 +35,7 @@ export const INITIAL_GAME_STATE: GameState = {
   timesSolved: 0,
   previousTimes: [],
   won: false,
+  clipboardNotes: null,
 };
 
 // Action types
@@ -50,6 +52,7 @@ const ACTIVATE_NOTES_MODE = "game/ACTIVATE_NOTES_MODE";
 const DEACTIVATE_NOTES_MODE = "game/DEACTIVATE_NOTES_MODE";
 const UPDATE_TIMER = "game/UPDATE_TIME";
 const RESET_GAME = "game/RESET_GAME";
+const COPY_NOTES = "game/COPY_NOTES";
 
 type GameAction =
   | {
@@ -76,7 +79,8 @@ type GameAction =
   | {type: typeof DEACTIVATE_NOTES_MODE}
   | {type: typeof UPDATE_TIMER; secondsPlayed: number}
   | {type: typeof RESET_GAME}
-  | {type: typeof WON_GAME};
+  | {type: typeof WON_GAME}
+  | {type: typeof COPY_NOTES; notes: number[]};
 
 function gameReducer(state: GameState, action: GameAction): GameState {
   switch (action.type) {
@@ -166,6 +170,11 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         state: GameStateMachine.running,
         won: false,
       };
+    case COPY_NOTES:
+      return {
+        ...state,
+        clipboardNotes: action.notes,
+      };
     default:
       return state;
   }
@@ -191,6 +200,7 @@ interface GameContextType {
   deactivateNotesMode: () => void;
   updateTimer: (secondsPlayed: number) => void;
   resetGame: () => void;
+  copyNotes: (notes: number[]) => void;
 }
 
 const GameContext = createContext<GameContextType | undefined>(undefined);
@@ -261,6 +271,10 @@ export function GameProvider({children, initialState = INITIAL_GAME_STATE}: Game
     dispatch({type: RESET_GAME});
   }, []);
 
+  const copyNotes = useCallback((notes: number[]) => {
+    dispatch({type: COPY_NOTES, notes});
+  }, []);
+
   const value = {
     state,
     newGame,
@@ -276,6 +290,7 @@ export function GameProvider({children, initialState = INITIAL_GAME_STATE}: Game
     deactivateNotesMode,
     updateTimer,
     resetGame,
+    copyNotes,
   };
 
   return <GameContext.Provider value={value}>{children}</GameContext.Provider>;

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -16,6 +16,7 @@
   "note_mode": "N: Notizmodus betreten/verlassen",
   "undo": "STRG + Z: Rückgängig",
   "redo": "STRG + Y: Wiederholen",
+  "copy_paste_notes": "STRG + C/V: Notizen kopieren/einfügen",
   "show_auto_notes": "Automatisch generierte Notizen anzeigen",
   "highlight_wrong_entries": "Falsche Einträge hervorheben",
   "highlight_conflicts": "Konflikte hervorheben",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
   "note_mode": "N: Enter/exit note mode",
   "undo": "CTRL + Z: Undo",
   "redo": "CTRL + Y: Redo",
+  "copy_paste_notes": "CTRL + C/V: Copy/paste notes",
   "show_auto_notes": "Show auto generated notes",
   "highlight_wrong_entries": "Highlight wrong entries",
   "highlight_conflicts": "Highlight conflicts",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -16,6 +16,7 @@
   "note_mode": "N: Entrar/salir del modo de notas",
   "undo": "CTRL + Z: Deshacer",
   "redo": "CTRL + Y: Rehacer",
+  "copy_paste_notes": "CTRL + C/V: Copiar/pegar notas",
   "show_auto_notes": "Mostrar notas generadas automáticamente",
   "highlight_wrong_entries": "Resaltar entradas incorrectas",
   "highlight_conflicts": "Resaltar conflictos",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -16,6 +16,7 @@
   "note_mode": "N : Mode note",
   "undo": "CTRL + Z : Annuler",
   "redo": "CTRL + Y : Rétablir",
+  "copy_paste_notes": "CTRL + C/V : Copier/coller les notes",
   "show_auto_notes": "Afficher les notes automatiques",
   "highlight_wrong_entries": "Surligner les erreurs",
   "highlight_conflicts": "Surligner les conflits",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -16,6 +16,7 @@
   "note_mode": "N: Entra/esci dalla modalità note",
   "undo": "CTRL + Z: Annulla",
   "redo": "CTRL + Y: Ripeti",
+  "copy_paste_notes": "CTRL + C/V: Copia/incolla note",
   "show_auto_notes": "Mostra note generate automaticamente",
   "highlight_wrong_entries": "Evidenzia voci errate",
   "highlight_conflicts": "Evidenzia conflitti",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -16,6 +16,7 @@
   "note_mode": "N: Entrar/sair do modo de notas",
   "undo": "CTRL + Z: Desfazer",
   "redo": "CTRL + Y: Refazer",
+  "copy_paste_notes": "CTRL + C/V: Copiar/colar notas",
   "show_auto_notes": "Mostrar notas geradas automaticamente",
   "highlight_wrong_entries": "Destacar entradas incorretas",
   "highlight_conflicts": "Destacar conflitos",

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -256,6 +256,7 @@ const SettingsAndInformation = () => {
               <li>{t("note_mode")}</li>
               <li>{t("undo")}</li>
               <li>{t("redo")}</li>
+              <li>{t("copy_paste_notes")}</li>
             </ul>
           </div>
         </div>
@@ -328,6 +329,7 @@ const GameInner: React.FC<{
   resetGame: () => void;
   deactivateNotesMode: () => void;
   setDisableAutoSync: (disabled: boolean) => void;
+  copyNotes: (notes: number[]) => void;
 }> = ({
   sudokuState,
   setSudoku,
@@ -349,6 +351,7 @@ const GameInner: React.FC<{
   resetGame,
   deactivateNotesMode,
   setDisableAutoSync,
+  copyNotes,
 }) => {
   const canUndo = sudokuState.historyIndex < sudokuState.history.length - 1;
   const sudoku = sudokuState.current;
@@ -410,6 +413,8 @@ const GameInner: React.FC<{
           notesMode={game.notesMode}
           showHints={userPreferencesState.showHints}
           selectCell={selectCell}
+          clipboardNotes={game.clipboardNotes}
+          copyNotes={copyNotes}
         />
         <header className="flex justify-between sm:items-center mt-4">
           <div className="flex text-white flex-col sm:flex-row sm:justify-end sm:items-center gap-2">
@@ -574,6 +579,7 @@ const GameWithRouteManagement = () => {
     deactivateNotesMode,
     resetGame,
     hideMenu,
+    copyNotes,
   } = useGame();
   const {
     state: userPreferencesState,
@@ -737,6 +743,7 @@ const GameWithRouteManagement = () => {
       resetGame={resetGame}
       deactivateNotesMode={deactivateNotesMode}
       setDisableAutoSync={setDisableAutoSync}
+      copyNotes={copyNotes}
     />
   );
 };

--- a/src/pages/Game/shortcuts/GridShortcuts.tsx
+++ b/src/pages/Game/shortcuts/GridShortcuts.tsx
@@ -21,6 +21,8 @@ const GridShortcuts: React.FC<{
   notesMode: boolean;
   showHints: boolean;
   selectCell: (cell: Cell) => void;
+  clipboardNotes: number[] | null;
+  copyNotes: (notes: number[]) => void;
 }> = ({
   pauseGame,
   activateNotesMode,
@@ -36,6 +38,8 @@ const GridShortcuts: React.FC<{
   notesMode,
   showHints,
   selectCell,
+  clipboardNotes,
+  copyNotes,
 }) => {
   // Use refs to store current values so shortcuts don't need to be recreated
   const stateRef = React.useRef({
@@ -53,6 +57,8 @@ const GridShortcuts: React.FC<{
     setNotes,
     undo,
     redo,
+    clipboardNotes,
+    copyNotes,
   });
 
   // Update refs with current values
@@ -72,6 +78,8 @@ const GridShortcuts: React.FC<{
       setNotes,
       undo,
       redo,
+      clipboardNotes,
+      copyNotes,
     };
   });
 
@@ -196,6 +204,22 @@ const GridShortcuts: React.FC<{
 
     hotkeys("ctrl+y,cmd+y", ShortcutScope.Game, () => {
       stateRef.current.redo();
+      return false;
+    });
+
+    hotkeys("ctrl+c,cmd+c", ShortcutScope.Game, () => {
+      const {activeCell, copyNotes} = stateRef.current;
+      if (activeCell && activeCell.notes.length > 0) {
+        copyNotes(activeCell.notes);
+      }
+      return false;
+    });
+
+    hotkeys("ctrl+v,cmd+v", ShortcutScope.Game, () => {
+      const {activeCell, clipboardNotes, setNotes} = stateRef.current;
+      if (activeCell && !activeCell.initial && clipboardNotes && clipboardNotes.length > 0) {
+        setNotes(activeCell, clipboardNotes);
+      }
       return false;
     });
 

--- a/src/pages/Game/shortcuts/Shortcuts.tsx
+++ b/src/pages/Game/shortcuts/Shortcuts.tsx
@@ -23,6 +23,8 @@ interface ShortcutsProps {
   notesMode: boolean;
   showHints: boolean;
   selectCell: (cell: Cell) => void;
+  clipboardNotes: number[] | null;
+  copyNotes: (notes: number[]) => void;
 }
 
 const Shortcuts: React.FC<ShortcutsProps> = ({
@@ -42,6 +44,8 @@ const Shortcuts: React.FC<ShortcutsProps> = ({
   notesMode,
   showHints,
   selectCell,
+  clipboardNotes,
+  copyNotes,
 }) => {
   useEffect(() => {
     if (gameState === GameStateMachine.paused) {
@@ -71,6 +75,8 @@ const Shortcuts: React.FC<ShortcutsProps> = ({
         notesMode={notesMode}
         showHints={showHints}
         selectCell={selectCell}
+        clipboardNotes={clipboardNotes}
+        copyNotes={copyNotes}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts to copy and paste cell notes between cells
- Adds Ctrl/Cmd+C to copy notes from selected cell
- Adds Ctrl/Cmd+V to paste notes to selected cell
- Includes translations for the shortcut description in all supported languages (en, de, es, fr, it, pt)

## Test plan
- [ ] Select a cell with notes and press Ctrl/Cmd+C
- [ ] Select another cell and press Ctrl/Cmd+V
- [ ] Verify notes are copied to the new cell
- [ ] Verify shortcut appears in keyboard shortcuts documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)