### PR TITLE
Add Playwright e2e coverage

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,4 +1,4 @@
-name: Run unit tests
+name: Run tests
 
 on:
   workflow_dispatch:
@@ -6,22 +6,23 @@ on:
     branches: '**'
 
 jobs:
-  unit-test:
+  test:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v2
-      with:
-        version: 8
     - uses: actions/setup-node@v4
       with:
-        node-version: '21'
+        node-version: '24'
         cache: npm
         cache-dependency-path: ./package-lock.json
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Run unit tests
       run: npm test
     - name: Run type checks
       run: npm run typecheck
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
+    - name: Run Playwright e2e tests
+      run: npm run test:e2e

--- a/e2e/sudoku.e2e.ts
+++ b/e2e/sudoku.e2e.ts
@@ -1,0 +1,216 @@
+import {expect, Page, test} from "@playwright/test";
+
+const FIRST_PUZZLE =
+  "534920700060007309900000010008700000496803002721594806000200940800046100003000000";
+const FIRST_SOLUTION =
+  "534921768162487359987635214358762491496813572721594836615278943879346125243159687";
+const ONE_EMPTY_CELL_PUZZLE = `${FIRST_SOLUTION.slice(0, -1)}0`;
+const SHORTCUT_MODIFIER = "Control";
+
+function gameUrl(sudoku = FIRST_PUZZLE, sudokuIndex = 1, sudokuCollectionName = "easy") {
+  const params = new URLSearchParams({
+    sudokuIndex: String(sudokuIndex),
+    sudoku,
+    sudokuCollectionName,
+  });
+
+  return `/#/?${params.toString()}`;
+}
+
+function cell(page: Page, x: number, y: number) {
+  return page.getByTestId(`sudoku-cell-${x}-${y}`);
+}
+
+function cellValue(page: Page, x: number, y: number) {
+  return page.getByTestId(`sudoku-cell-value-${x}-${y}`);
+}
+
+function cellNotes(page: Page, x: number, y: number) {
+  return page.getByTestId(`sudoku-cell-notes-${x}-${y}`);
+}
+
+async function openGame(page: Page, sudoku = FIRST_PUZZLE, sudokuIndex = 1, collection = "easy", label = "Easy") {
+  await page.goto(gameUrl(sudoku, sudokuIndex, collection));
+  await expect(page.getByTestId("current-game-label")).toHaveText(`${label} #${sudokuIndex}`);
+  await expect(page.getByTestId("sudoku-board")).toBeVisible();
+  await continueIfPaused(page);
+  await expect(cellValue(page, 5, 0)).toHaveText(sudoku[5] === "0" ? "" : sudoku[5]);
+}
+
+async function continueIfPaused(page: Page) {
+  const continueButton = page.getByRole("button", {name: "Continue"});
+  if (await continueButton.isVisible()) {
+    await continueButton.click();
+  }
+  await expect(page.getByRole("button", {name: "Pause"})).toBeVisible();
+}
+
+async function selectCell(page: Page, x: number, y: number) {
+  await cell(page, x, y).click();
+  await expect(cell(page, x, y)).toHaveAttribute("data-cell-active", "true");
+}
+
+async function expectStoredPreferences(page: Page, preferences: Record<string, boolean>) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const rawPreferences = localStorage.getItem("super-sudoku-user-preferences");
+        return rawPreferences ? JSON.parse(rawPreferences) : null;
+      }),
+    )
+    .toMatchObject(preferences);
+}
+
+test.beforeEach(async ({context}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"], {origin: "http://127.0.0.1:4173"});
+});
+
+test("supports number entry, erase, undo, redo, notes, hints, and keyboard shortcuts", async ({page}) => {
+  await openGame(page);
+
+  await selectCell(page, 5, 0);
+  await page.getByRole("button", {name: "Set 1"}).click();
+  await expect(cellValue(page, 5, 0)).toHaveText("1");
+
+  await page.getByRole("button", {name: "Erase"}).click();
+  await expect(cellValue(page, 5, 0)).toHaveText("");
+
+  await page.getByRole("button", {name: "Set 2"}).click();
+  await expect(cellValue(page, 5, 0)).toHaveText("2");
+
+  await page.getByRole("button", {name: "Undo"}).click();
+  await expect(cellValue(page, 5, 0)).toHaveText("");
+
+  await page.keyboard.press(`${SHORTCUT_MODIFIER}+Y`);
+  await expect(cellValue(page, 5, 0)).toHaveText("2");
+
+  await page.keyboard.press("Backspace");
+  await expect(cellValue(page, 5, 0)).toHaveText("");
+
+  await page.keyboard.press("ArrowRight");
+  await expect(cell(page, 6, 0)).toHaveAttribute("data-cell-active", "true");
+  await page.keyboard.press("ArrowRight");
+  await expect(cell(page, 7, 0)).toHaveAttribute("data-cell-active", "true");
+  await page.keyboard.press("6");
+  await expect(cellValue(page, 7, 0)).toHaveText("6");
+
+  await selectCell(page, 8, 0);
+  await page.keyboard.press("h");
+  await expect(cellValue(page, 8, 0)).toHaveText("8");
+
+  await selectCell(page, 5, 0);
+  await page.keyboard.press("n");
+  await expect(cell(page, 5, 0)).toHaveAttribute("data-cell-notes-mode", "true");
+  await page.keyboard.press("3");
+  await page.keyboard.press("4");
+  await expect(cellNotes(page, 5, 0)).toContainText("3");
+  await expect(cellNotes(page, 5, 0)).toContainText("4");
+
+  await page.keyboard.press(`${SHORTCUT_MODIFIER}+C`);
+  await selectCell(page, 0, 1);
+  await page.keyboard.press(`${SHORTCUT_MODIFIER}+V`);
+  await expect(cellNotes(page, 0, 1)).toContainText("3");
+  await expect(cellNotes(page, 0, 1)).toContainText("4");
+
+  await page.keyboard.press("n");
+  await page.keyboard.press("5");
+  await expect(cellValue(page, 0, 1)).toHaveText("5");
+  await expect(cellNotes(page, 0, 1)).toHaveText("");
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("button", {name: "Continue"})).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("button", {name: "Pause"})).toBeVisible();
+});
+
+test("persists game settings, dark mode, and language selection", async ({page}) => {
+  await openGame(page);
+
+  await page.locator("#generated_notes").check();
+  await expect(cellNotes(page, 5, 0)).toContainText("1");
+
+  await page.locator("#show_occurrences").check();
+  await expect(page.getByTestId("sudoku-number-occurrences-5")).toBeVisible();
+
+  await page.locator("#highlight_conflicts").uncheck();
+  await page.locator("#highlight_wrong_entries").check();
+  await selectCell(page, 5, 0);
+  await page.getByRole("button", {name: "Set 2"}).click();
+  await expect(cell(page, 5, 0)).toHaveAttribute("data-cell-conflict", "true");
+
+  await page.locator("#circle_menu").uncheck();
+  await selectCell(page, 7, 0);
+  await expect(page.getByTestId("sudoku-menu-circle")).toHaveCount(0);
+
+  await expectStoredPreferences(page, {
+    showHints: true,
+    showWrongEntries: true,
+    showConflicts: false,
+    showCircleMenu: false,
+    showOccurrences: true,
+  });
+
+  await page.reload();
+  await expect(page.locator("#generated_notes")).toBeChecked();
+  await expect(page.locator("#highlight_wrong_entries")).toBeChecked();
+  await expect(page.locator("#highlight_conflicts")).not.toBeChecked();
+  await expect(page.locator("#circle_menu")).not.toBeChecked();
+  await expect(page.locator("#show_occurrences")).toBeChecked();
+
+  await page.getByRole("button", {name: "Toggle dark mode"}).click();
+  await expect(page.locator("body")).toHaveClass(/dark/);
+  await expect.poll(() => page.evaluate(() => localStorage.getItem("darkMode"))).toBe("true");
+
+  await page.getByLabel("Select language").selectOption("es");
+  await expect(page.getByRole("button", {name: "Nuevo juego"})).toBeVisible();
+  await expect.poll(() => page.evaluate(() => localStorage.getItem("language"))).toBe("es");
+
+  await page.reload();
+  await expect(page.getByRole("button", {name: "Nuevo juego"})).toBeVisible();
+});
+
+test("solves a sudoku and starts the next game from the win screen", async ({page}) => {
+  await openGame(page, ONE_EMPTY_CELL_PUZZLE);
+
+  await selectCell(page, 8, 8);
+  await page.getByRole("button", {name: "Set 7"}).click();
+
+  await expect(page.getByText(/Congrats, you won/)).toBeVisible();
+  await page.getByRole("button", {name: "Select next sudoku: Easy #2"}).click();
+
+  await expect(page.getByTestId("current-game-label")).toHaveText("Easy #2");
+  await expect(page.getByText(/Congrats, you won/)).toHaveCount(0);
+  await expect(page).toHaveURL(/sudokuCollectionName=easy/);
+});
+
+test("changes games through the selection screen", async ({page}) => {
+  await openGame(page);
+
+  await page.getByRole("button", {name: "New game"}).click();
+  await expect(page.getByRole("heading", {name: "Select Game"})).toBeVisible();
+
+  await page.getByRole("button", {name: "Medium"}).click();
+  await page.getByTestId("sudoku-preview-1").click();
+
+  await expect(page.getByTestId("current-game-label")).toHaveText("Medium #1");
+  await expect(page).toHaveURL(/sudokuCollectionName=medium/);
+});
+
+test("copies a shareable sudoku URL that opens the same puzzle", async ({context, page}) => {
+  await openGame(page);
+
+  await page.getByTestId("share-sudoku").click();
+  await expect(page.getByTestId("share-sudoku")).toContainText("Copied");
+
+  const shareUrl = await page.evaluate(() => navigator.clipboard.readText());
+  expect(shareUrl).toContain("#/?");
+  expect(shareUrl).toContain(`sudoku=${FIRST_PUZZLE}`);
+  expect(shareUrl).toContain("sudokuCollectionName=easy");
+
+  const sharedPage = await context.newPage();
+  await sharedPage.goto(shareUrl);
+  await expect(sharedPage.getByTestId("current-game-label")).toHaveText("Easy #1");
+  await continueIfPaused(sharedPage);
+  await expect(cellValue(sharedPage, 0, 0)).toHaveText("5");
+  await expect(cellValue(sharedPage, 5, 0)).toHaveText("");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "tailwind-merge": "3.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/forms": "0.5.7",
         "@types/lodash-es": "4.17.12",
         "@types/node": "24.3.1",
@@ -2461,6 +2462,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -7712,6 +7729,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview",
     "clean": "rm -rf dist/",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "test:watch": "vitest",
     "start": "vite",
     "typecheck": "tsc --noEmit",
@@ -34,6 +36,7 @@
     "game"
   ],
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/forms": "0.5.7",
     "@types/lodash-es": "4.17.12",
     "@types/node": "24.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import {defineConfig, devices} from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.e2e.ts",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["github"], ["html", {open: "never"}]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    colorScheme: "light",
+    locale: "en-US",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {...devices["Desktop Chrome"]},
+    },
+  ],
+  webServer: {
+    command: "npm run build && npm run preview -- --host 127.0.0.1 --port 4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    url: "http://127.0.0.1:4173",
+  },
+});

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,22 +2,15 @@ import clsx from "clsx";
 import React from "react";
 import {twMerge} from "tailwind-merge";
 
-const Button = ({
-  children,
-  className,
-  disabled,
-  active,
-  onClick,
-}: {
-  children: React.ReactNode;
-  className?: string;
-  disabled?: boolean;
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   active?: boolean;
-  onClick?: () => void;
-}) => {
+};
+
+const Button = ({children, className, disabled, active, onClick, type = "button", ...props}: ButtonProps) => {
   return (
     <button
       onClick={onClick}
+      type={type}
       className={twMerge(
         clsx(
           "rounded-sm border-none bg-white dark:text-white dark:bg-gray-500 md:px-4 md:py-2 px-2 py-1 text-black shadow-sm transition-transform hover:brightness-90 focus:outline-none disabled:brightness-75",
@@ -28,6 +21,7 @@ const Button = ({
         ),
       )}
       disabled={disabled}
+      {...props}
     >
       {children}
     </button>

--- a/src/components/DarkModeButton.tsx
+++ b/src/components/DarkModeButton.tsx
@@ -48,7 +48,11 @@ export const DarkModeButton = () => {
   };
 
   return (
-    <button onClick={toggleDarkMode} className="md:h-10 md:w-10 h-8 w-8 rounded-sm p-1 hover:bg-gray-800">
+    <button
+      aria-label="Toggle dark mode"
+      onClick={toggleDarkMode}
+      className="md:h-10 md:w-10 h-8 w-8 rounded-sm p-1 hover:bg-gray-800"
+    >
       <svg className="fill-violet-700 block dark:hidden" fill="currentColor" viewBox="0 0 20 20">
         <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
       </svg>

--- a/src/components/sudoku/Sudoku.tsx
+++ b/src/components/sudoku/Sudoku.tsx
@@ -55,6 +55,8 @@ const SudokuCell = React.memo(
     notesMode,
     conflict,
     highlightNumber,
+    x,
+    y,
   }: {
     number: number;
     active: boolean;
@@ -69,23 +71,41 @@ const SudokuCell = React.memo(
     initial: boolean;
     notes: number[];
     notesMode: boolean;
+    x: number;
+    y: number;
   }) => {
+    const row = y + 1;
+    const column = x + 1;
+
     return (
       <div>
         <GridCell
+          ariaLabel={`${initial ? "Given" : "Editable"} cell row ${row} column ${column}${
+            number === 0 ? " empty" : ` value ${number}`
+          }`}
           notesMode={notesMode}
           active={active}
           conflict={conflict}
           highlight={highlight}
           highlightNumber={highlightNumber}
           bounds={bounds}
+          initial={initial}
+          number={number}
           onClick={onClick}
           onRightClick={onRightClick}
+          testId={`sudoku-cell-${x}-${y}`}
         />
-        <GridCellNumber left={left} top={top} initial={initial} highlight={highlightNumber} conflict={conflict}>
+        <GridCellNumber
+          left={left}
+          top={top}
+          initial={initial}
+          highlight={highlightNumber}
+          conflict={conflict}
+          testId={`sudoku-cell-value-${x}-${y}`}
+        >
           {number !== 0 ? number : ""}
         </GridCellNumber>
-        <CellNoteContainer initial={initial} bounds={bounds}>
+        <CellNoteContainer initial={initial} bounds={bounds} testId={`sudoku-cell-notes-${x}-${y}`}>
           {initial || number
             ? null
             : notes.map((n) => {
@@ -180,7 +200,7 @@ export const Sudoku: React.FC<SudokuProps> = ({
   }, [activeCell, hideMenu]);
 
   return (
-    <div className="relative" ref={sudokuContainerRef} style={{height: containerWidth}}>
+    <div className="relative" data-testid="sudoku-board" ref={sudokuContainerRef} style={{height: containerWidth}}>
       {children}
       <div className="absolute h-full w-full rounded-sm">
         <SudokuGrid width={width} height={height} hideLeftRight />
@@ -238,6 +258,8 @@ export const Sudoku: React.FC<SudokuProps> = ({
               number={c.number}
               initial={c.initial}
               notesMode={notesMode}
+              x={c.x}
+              y={c.y}
             />
           );
         })}

--- a/src/components/sudoku/SudokuGrid.tsx
+++ b/src/components/sudoku/SudokuGrid.tsx
@@ -49,13 +49,16 @@ export const CellNoteContainer = ({
   initial,
   bounds,
   children,
+  testId,
 }: {
   initial: boolean;
   bounds: Bounds;
   children: React.ReactNode;
+  testId?: string;
 }) => {
   return (
     <div
+      data-testid={testId}
       style={{
         width: `${bounds.width}%`,
         height: `${bounds.height}%`,
@@ -78,6 +81,10 @@ export const GridCell = ({
   bounds,
   active,
   notesMode,
+  initial,
+  number,
+  testId,
+  ariaLabel,
   onClick,
   onRightClick,
 }: {
@@ -87,6 +94,10 @@ export const GridCell = ({
   bounds: Bounds;
   active: boolean;
   notesMode: boolean;
+  initial: boolean;
+  number: number;
+  testId?: string;
+  ariaLabel?: string;
   onClick: () => void;
   onRightClick: () => void;
 }) => {
@@ -119,6 +130,13 @@ export const GridCell = ({
   return (
     <>
       <div
+        aria-label={ariaLabel}
+        data-cell-active={active ? "true" : "false"}
+        data-cell-conflict={conflict ? "true" : "false"}
+        data-cell-initial={initial ? "true" : "false"}
+        data-cell-notes-mode={notesMode ? "true" : "false"}
+        data-cell-value={number === 0 ? "" : number}
+        data-testid={testId}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -146,6 +164,7 @@ export const GridCellNumber = ({
   left,
   top,
   children,
+  testId,
   // TODO: distinguish between wrong and conflicted.
   conflict,
 }: {
@@ -155,9 +174,11 @@ export const GridCellNumber = ({
   left: number;
   top: number;
   children: React.ReactNode;
+  testId?: string;
 }) => {
   return (
     <div
+      data-testid={testId}
       style={{
         left: `${left}%`,
         top: `${top}%`,

--- a/src/components/sudoku/SudokuMenuCircle.tsx
+++ b/src/components/sudoku/SudokuMenuCircle.tsx
@@ -136,6 +136,7 @@ const MenuCircle: React.FC<{
   return (
     <svg
       className="hidden md:block absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 select-none"
+      data-testid="sudoku-menu-circle"
       style={{
         height: circleRadius * 4,
         width: circleRadius * 4,

--- a/src/components/sudoku/SudokuMenuNumbers.tsx
+++ b/src/components/sudoku/SudokuMenuNumbers.tsx
@@ -53,6 +53,7 @@ const SudokuMenuNumbers: React.FC<SudokuMenuNumbersProps> = ({
 
         return (
           <Button
+            aria-label={`Set ${n}`}
             className={clsx("relative font-bold", {
               "bg-gray-400": occurrences == 9,
               "bg-red-400 dark:bg-red-400": showOccurrences && occurrences > 9,
@@ -65,11 +66,15 @@ const SudokuMenuNumbers: React.FC<SudokuMenuNumbersProps> = ({
                 !userNotes.includes(n) &&
                 activeCellData?.number === 0,
             })}
+            data-testid={`sudoku-number-${n}`}
             onClick={setNumberOrNote}
             key={n}
           >
             {showOccurrences && (
-              <div className="absolute right-0 bottom-0 h-3 w-3 rounded-xl bg-teal-700 text-xxs text-white opacity-70 sm:right-1 sm:bottom-1 sm:h-4 sm:w-4 sm:text-xs ">
+              <div
+                className="absolute right-0 bottom-0 h-3 w-3 rounded-xl bg-teal-700 text-xxs text-white opacity-70 sm:right-1 sm:bottom-1 sm:h-4 sm:w-4 sm:text-xs "
+                data-testid={`sudoku-number-occurrences-${n}`}
+              >
                 {occurrences}
               </div>
             )}

--- a/src/components/sudoku/SudokuPreview.tsx
+++ b/src/components/sudoku/SudokuPreview.tsx
@@ -72,7 +72,10 @@ export default class SudokuPreview extends React.PureComponent<{
 
     return (
       <div
+        aria-label={`Select sudoku ${id}`}
         className="user-select-none hover:cursor-pointer group"
+        data-testid={`sudoku-preview-${id}`}
+        role="button"
         tabIndex={id + 4}
         onClick={onClick}
         onKeyDown={onKeyDown}

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -206,7 +206,12 @@ const ShareButton: React.FC<{
 
   const handleShare = async () => {
     const stringifiedSudoku = stringifySudoku(cellsToSimpleSudoku(sudokuState.current));
-    const shareUrl = `${window.location.origin}/?sudokuIndex=${gameState.sudokuIndex + 1}&sudoku="${stringifiedSudoku}"&sudokuCollectionName=${gameState.sudokuCollectionName}`;
+    const params = new URLSearchParams({
+      sudokuIndex: String(gameState.sudokuIndex + 1),
+      sudoku: stringifiedSudoku,
+      sudokuCollectionName: gameState.sudokuCollectionName,
+    });
+    const shareUrl = `${window.location.origin}${window.location.pathname}#/?${params.toString()}`;
 
     await copyToClipboard(shareUrl);
     setCopied(true);
@@ -216,15 +221,22 @@ const ShareButton: React.FC<{
   const {t} = useTranslation();
 
   return (
-    <div className="text-white hover:cursor-pointer p-1 hover:bg-gray-500 rounded-md" onClick={handleShare}>
+    <button
+      aria-label={t("share")}
+      className="text-white hover:cursor-pointer p-1 hover:bg-gray-500 rounded-md border-none bg-transparent"
+      data-testid="share-sudoku"
+      onClick={handleShare}
+      type="button"
+    >
       {copied ? t("copied") : `🔗 ${t("share")}`}
-    </div>
+    </button>
   );
 };
 
 const CenteredContinueButton: React.FC<{visible: boolean; onClick: () => void}> = ({visible, onClick}) => (
   <div
     onClick={onClick}
+    data-testid="continue-overlay"
     className={`${visible ? "flex" : "hidden"} justify-center items-center w-full h-full absolute z-30 hover:cursor-pointer`}
   >
     <>
@@ -240,6 +252,57 @@ const DifficultyShow = ({children, ...props}: React.HTMLAttributes<HTMLDivElemen
     {children}
   </div>
 );
+
+function stripWrappingQuotes(value: string) {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function getRawSearchParam(name: string) {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  const hashSearch = window.location.hash.includes("?") ? window.location.hash.split("?")[1] : "";
+  const searchSources = [hashSearch, window.location.search.replace(/^\?/, "")].filter(Boolean);
+
+  for (const source of searchSources) {
+    const value = new URLSearchParams(source).get(name);
+    if (value !== null) {
+      return stripWrappingQuotes(value);
+    }
+  }
+
+  return undefined;
+}
+
+function getSearchString(search: Record<string, unknown>, name: string) {
+  const rawValue = getRawSearchParam(name);
+  if (rawValue !== undefined) {
+    return rawValue;
+  }
+
+  const value = search[name];
+  if (typeof value === "string") {
+    return stripWrappingQuotes(value);
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return value.toString();
+  }
+  return undefined;
+}
+
+function getSearchNumber(search: Record<string, unknown>, name: string) {
+  const value = getSearchString(search, name);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
 
 const SettingsAndInformation = () => {
   const {
@@ -430,7 +493,9 @@ const GameInner: React.FC<{
         <header className="flex justify-between sm:items-center mt-4">
           <div className="flex text-white flex-col sm:flex-row sm:justify-end sm:items-center gap-2">
             <div className="flex gap-2 items-center">
-              <DifficultyShow>{`${translateCollectionName(game.sudokuCollectionName)} #${game.sudokuIndex + 1}`}</DifficultyShow>
+              <DifficultyShow data-testid="current-game-label">{`${translateCollectionName(
+                game.sudokuCollectionName,
+              )} #${game.sudokuIndex + 1}`}</DifficultyShow>
               <ShareButton gameState={game} sudokuState={sudokuState} />
             </div>
             <div className="hidden sm:block">{"|"}</div>
@@ -592,14 +657,7 @@ const GameWithRouteManagement = () => {
     hideMenu,
     copyNotes,
   } = useGame();
-  const {
-    state: userPreferencesState,
-    toggleShowHints,
-    toggleShowOccurrences,
-    toggleShowCircleMenu,
-    toggleShowWrongEntries,
-    toggleShowConflicts,
-  } = useUserPreferences();
+  const {state: userPreferencesState} = useUserPreferences();
   const {
     setSudokuState,
     state: sudokuState,
@@ -617,10 +675,10 @@ const GameWithRouteManagement = () => {
   const {t} = useTranslation();
 
   const currentPath = location.pathname;
-  const search = location.search;
-  const sudokuIndex = search["sudokuIndex"] as number | undefined;
-  const sudoku = search["sudoku"] as string | undefined;
-  const sudokuCollectionName = search["sudokuCollectionName"] as string | undefined;
+  const search = location.search as Record<string, unknown>;
+  const sudokuIndex = getSearchNumber(search, "sudokuIndex");
+  const sudoku = getSearchString(search, "sudoku");
+  const sudokuCollectionName = getSearchString(search, "sudokuCollectionName");
 
   useEffect(() => {
     if (gameState && sudokuState && initialized && currentPath === "/" && !disableAutoSync) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,8 +23,10 @@
     },
   },
   "include": [
+    "e2e",
     "src",
     "scripts",
+    "playwright.config.ts",
     "vite.config.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add Playwright config and end-to-end tests for Sudoku gameplay, settings, language, game selection, next game, and sharing
- add stable selectors/accessibility labels needed for reliable browser coverage
- run Playwright in GitHub Actions alongside unit tests and typecheck
- fix hash-based share/custom Sudoku URLs so copied puzzle links reopen correctly

## Verification
- npm test
- npm run typecheck
- npm run lint
- npm run test:e2e