### PR TITLE
Expose Playwright traces and videos in CI

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -5,6 +5,11 @@ on:
   push:
     branches: '**'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -26,3 +31,33 @@ jobs:
       run: npx playwright install --with-deps chromium
     - name: Run Playwright e2e tests
       run: npm run test:e2e
+    - name: Upload Playwright HTML report
+      id: upload-playwright-report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/
+        if-no-files-found: ignore
+        retention-days: 14
+    - name: Upload Playwright traces and videos
+      id: upload-playwright-results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-results
+        path: test-results/
+        if-no-files-found: ignore
+        retention-days: 14
+    - name: Summarize Playwright e2e results
+      if: always()
+      env:
+        PLAYWRIGHT_REPORT_URL: ${{ steps.upload-playwright-report.outputs.artifact-url }}
+        PLAYWRIGHT_RESULTS_URL: ${{ steps.upload-playwright-results.outputs.artifact-url }}
+        PLAYWRIGHT_SUMMARY_PATH: playwright-summary.md
+      run: node scripts/summarize_playwright_results.js test-results/playwright-results.json
+    - name: Post Playwright e2e PR comment
+      if: always()
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: node scripts/upsert_playwright_comment.js playwright-summary.md

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -100,6 +100,16 @@ export default [
     },
   },
 
+  // JavaScript helper scripts
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
   // Ignore build output and other files
   {
     ignores: ['dist/**', 'node_modules/**', '*.min.js', 'coverage/**', 'postcss.config.js', 'prettier.config.js', 'tailwind.config.js'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,13 +6,20 @@ export default defineConfig({
   fullyParallel: true,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? [["github"], ["html", {open: "never"}]] : "list",
+  reporter: process.env.CI
+    ? [
+        ["github"],
+        ["html", {open: "never", outputFolder: "playwright-report"}],
+        ["json", {outputFile: "test-results/playwright-results.json"}],
+      ]
+    : "list",
   use: {
     baseURL: "http://127.0.0.1:4173",
     colorScheme: "light",
     locale: "en-US",
     screenshot: "only-on-failure",
-    trace: "on-first-retry",
+    trace: process.env.CI ? "on" : "retain-on-failure",
+    video: process.env.CI ? "on" : "retain-on-failure",
   },
   projects: [
     {

--- a/scripts/summarize_playwright_results.js
+++ b/scripts/summarize_playwright_results.js
@@ -1,0 +1,144 @@
+import fs from "node:fs";
+
+const resultsPath = process.argv[2] ?? "test-results/playwright-results.json";
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+const summaryOutputPath = process.env.PLAYWRIGHT_SUMMARY_PATH;
+const reportUrl = process.env.PLAYWRIGHT_REPORT_URL;
+const resultsUrl = process.env.PLAYWRIGHT_RESULTS_URL;
+const workflowRunUrl =
+  process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+    ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    : undefined;
+
+function flattenSuites(suites) {
+  return suites.flatMap((suite) => [suite, ...flattenSuites(suite.suites ?? [])]);
+}
+
+function clean(value) {
+  return String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function markdownEscape(value) {
+  return clean(value).replaceAll("|", "\\|");
+}
+
+function markdownLink(label, url) {
+  if (!url) {
+    return `\`${label}\``;
+  }
+  return `[${label}](${url})`;
+}
+
+function resultsInstructions() {
+  return `Download ${markdownLink(
+    "playwright-results.zip",
+    resultsUrl,
+  )}, unzip it, extract the nested \`*/trace.zip\` file you want, then upload that \`trace.zip\` to ${markdownLink(
+    "trace.playwright.dev",
+    "https://trace.playwright.dev/",
+  )}. Open extracted \`.webm\` files locally for videos.`;
+}
+
+function failureMessage(test) {
+  const failedResult = [...(test.results ?? [])]
+    .reverse()
+    .find((result) => ["failed", "timedOut", "interrupted"].includes(result.status));
+  const errors =
+    failedResult?.errors?.length > 0 ? failedResult.errors : failedResult?.error ? [failedResult.error] : [];
+  const firstError = errors.find(Boolean);
+
+  return firstError?.message ?? firstError?.value ?? "";
+}
+
+function collectFailedTests(results) {
+  return flattenSuites(results.suites ?? []).flatMap((suite) =>
+    (suite.specs ?? []).flatMap((spec) =>
+      (spec.tests ?? [])
+        .filter((test) => ["unexpected", "flaky"].includes(test.status))
+        .map((test) => ({
+          title: spec.title,
+          project: test.projectName,
+          status: test.status,
+          location: `${spec.file}:${spec.line}`,
+          message: failureMessage(test),
+        })),
+    ),
+  );
+}
+
+function renderSummary(results) {
+  const failedTests = collectFailedTests(results);
+  const stats = results.stats ?? {};
+  const lines = [
+    "## Playwright e2e results",
+    "",
+    `Expected: ${stats.expected ?? 0} | Flaky: ${stats.flaky ?? 0} | Failed: ${stats.unexpected ?? 0} | Skipped: ${stats.skipped ?? 0}`,
+    "",
+    "### Artifacts",
+    "",
+    `- ${markdownLink("playwright-report", reportUrl)}: HTML report for the full e2e run.`,
+    `- ${resultsInstructions()}`,
+  ];
+
+  if (workflowRunUrl) {
+    lines.push(`- Workflow run: ${markdownLink("Run details", workflowRunUrl)}.`);
+  }
+
+  lines.push("");
+
+  if (failedTests.length === 0) {
+    return [...lines, "### Failed tests", "", "No Playwright tests failed."].join("\n");
+  }
+
+  return [
+    ...lines,
+    "### Failed tests",
+    "",
+    "| Test | Project | Status | Location | Error |",
+    "| --- | --- | --- | --- | --- |",
+    ...failedTests.map(
+      (test) =>
+        `| ${markdownEscape(test.title)} | ${markdownEscape(test.project)} | ${markdownEscape(
+          test.status,
+        )} | ${markdownEscape(test.location)} | ${markdownEscape(test.message)} |`,
+    ),
+  ].join("\n");
+}
+
+function writeSummary(message) {
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${message}\n`);
+  }
+
+  if (summaryOutputPath) {
+    fs.writeFileSync(summaryOutputPath, `${message}\n`);
+  }
+
+  if (!summaryPath && !summaryOutputPath) {
+    console.log(message);
+  }
+}
+
+if (!fs.existsSync(resultsPath)) {
+  const message = [
+    "## Playwright e2e results",
+    "",
+    `No Playwright JSON results were found at \`${resultsPath}\`.`,
+    "",
+    `Check the ${markdownLink("playwright-report", reportUrl)} and ${markdownLink(
+      "playwright-results",
+      resultsUrl,
+    )} artifacts if they were uploaded.`,
+    resultsInstructions(),
+    workflowRunUrl ? `Workflow run: ${markdownLink("Run details", workflowRunUrl)}.` : "",
+  ].join("\n");
+
+  writeSummary(message);
+  process.exit(0);
+}
+
+const results = JSON.parse(fs.readFileSync(resultsPath, "utf8"));
+const summary = renderSummary(results);
+writeSummary(summary);

--- a/scripts/upsert_playwright_comment.js
+++ b/scripts/upsert_playwright_comment.js
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+
+const marker = "<!-- playwright-e2e-summary -->";
+const summaryPath = process.argv[2] ?? "playwright-summary.md";
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const branch = process.env.GITHUB_REF_NAME;
+const repositoryOwner = process.env.GITHUB_REPOSITORY_OWNER;
+const apiBaseUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+
+function canPostComment() {
+  return token && repository && branch && repositoryOwner && fs.existsSync(summaryPath);
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = new Error(`${options.method ?? "GET"} ${path} failed with ${response.status}: ${await response.text()}`);
+    error.status = response.status;
+    throw error;
+  }
+
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  return response.json();
+}
+
+async function findPullRequest(owner, repo) {
+  const params = new URLSearchParams({
+    head: `${repositoryOwner}:${branch}`,
+    state: "open",
+    per_page: "1",
+  });
+  const pullRequests = await request(`/repos/${owner}/${repo}/pulls?${params}`);
+
+  return pullRequests[0];
+}
+
+async function findExistingComment(owner, repo, issueNumber) {
+  const comments = await request(`/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`);
+
+  return comments.find(
+    (comment) => comment.user?.login === "github-actions[bot]" && String(comment.body ?? "").includes(marker),
+  );
+}
+
+async function upsertComment() {
+  if (!canPostComment()) {
+    console.log("Skipping Playwright PR comment because required GitHub context or summary file is missing.");
+    return;
+  }
+
+  const [owner, repo] = repository.split("/");
+  const pullRequest = await findPullRequest(owner, repo);
+
+  if (!pullRequest) {
+    console.log(`No open pull request found for ${repositoryOwner}:${branch}; skipping Playwright PR comment.`);
+    return;
+  }
+
+  const summary = fs.readFileSync(summaryPath, "utf8").trim();
+  const body = `${marker}\n\n${summary}`;
+  const existingComment = await findExistingComment(owner, repo, pullRequest.number);
+
+  if (existingComment) {
+    await request(`/repos/${owner}/${repo}/issues/comments/${existingComment.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({body}),
+    });
+    console.log(`Updated Playwright summary comment on PR #${pullRequest.number}.`);
+    return;
+  }
+
+  await request(`/repos/${owner}/${repo}/issues/${pullRequest.number}/comments`, {
+    method: "POST",
+    body: JSON.stringify({body}),
+  });
+  console.log(`Created Playwright summary comment on PR #${pullRequest.number}.`);
+}
+
+try {
+  await upsertComment();
+} catch (error) {
+  if (error.status === 403) {
+    console.log("Skipping Playwright PR comment because the GitHub token cannot write PR comments.");
+  } else {
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- record Playwright traces and videos for CI e2e runs
- upload the Playwright HTML report and raw test results as GitHub Actions artifacts
- add a job summary that lists failed Playwright tests and points to trace/video artifacts and https://trace.playwright.dev/

## Verification
- npm test
- npm run typecheck
- npm run lint
- CI=1 npm run test:e2e
- node scripts/summarize_playwright_results.js test-results/playwright-results.json